### PR TITLE
Upgrading Dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "zendframework/zendframework": "2.*",
         "doctrine/doctrine-orm-module": "0.*",
         "zf-commons/zfc-user": "0.*",
-        "zf-commons/zfc-user-doctrine-orm": "0.*"
+        "zf-commons/zfc-user-doctrine-orm": "^1.0"
     },
     "autoload": {
         "psr-0": {


### PR DESCRIPTION
Upgrading dependencies of

zf-commons/zfc-user-doctrine-orm

To be able to use the latest version.
